### PR TITLE
Fixed Arc Clipping Issue

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -21,7 +21,7 @@ export const ARC_DISTANCE_OFFSET = 225;
 export const ARC_LENGTH_OFFSET = 10;
 
 /**
- * Maximum Distance Allowed between Two Globe Points in order to Draw an Arc
+ * Maximum Distance Allowed between Two Arc Points in order to draw an Arc
  *
  * @note This will prevent Arcs from being drawn between points with distance > ARC_MAX_DISTANCE
  */

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,5 +1,4 @@
 /* eslint-disable import/prefer-default-export */
-export const COLOR_1 = '#ef0018';
 
 /**
  * Arc Point Distance at which Arc Length should begin increasing linearly to account for Arcs with
@@ -27,9 +26,9 @@ export const ARC_LENGTH_OFFSET = 10;
  */
 export const ARC_MAX_DISTANCE = 300;
 
+export const COLOR_1 = '#ef0018';
 export const GLOBE_DOT_MIN_OPACITY = 0.125;
 export const GLOBE_DOT_RADIUS = 2.9;
-
 export const TOTAL_ARCS = 20;
 
 export function onLocationClick(event, { locationMarker }) {

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,10 +1,17 @@
 /* eslint-disable import/prefer-default-export */
-export const TOTAL_ARCS = 20;
-
 export const COLOR_1 = '#ef0018';
+
+/**
+ * Maximum Length of Globe Curves that are drawn between Globe Points
+ *
+ * @note If curve distance is too large for a given sphere, the curves will clip into the sphere
+ */
+export const CURVE_MAX_DISTANCE = 225;
 
 export const GLOBE_DOT_MIN_OPACITY = 0.125;
 export const GLOBE_DOT_RADIUS = 2.9;
+
+export const TOTAL_ARCS = 20;
 
 export function onLocationClick(event, { locationMarker }) {
   const thisCard = document.getElementById(locationMarker.object.name);

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -2,13 +2,6 @@
 export const COLOR_1 = '#ef0018';
 
 /**
- * Maximum Distance Allowed between Two Globe Points in order to Draw an Arc
- *
- * @note This will prevent Arcs from being drawn between points with distance > ARC_MAX_DISTANCE
- */
-export const ARC_MAX_DISTANCE = 300;
-
-/**
  * Arc Point Distance at which Arc Length should begin increasing linearly to account for Arcs with
  * exceptionally large distance (ex: across globe, 180 degrees).
  *
@@ -26,6 +19,13 @@ export const ARC_DISTANCE_OFFSET = 225;
  * without changing the distance between the two points.
  */
 export const ARC_LENGTH_OFFSET = 10;
+
+/**
+ * Maximum Distance Allowed between Two Globe Points in order to Draw an Arc
+ *
+ * @note This will prevent Arcs from being drawn between points with distance > ARC_MAX_DISTANCE
+ */
+export const ARC_MAX_DISTANCE = 300;
 
 export const GLOBE_DOT_MIN_OPACITY = 0.125;
 export const GLOBE_DOT_RADIUS = 2.9;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -2,11 +2,30 @@
 export const COLOR_1 = '#ef0018';
 
 /**
- * Maximum Length of Globe Curves that are drawn between Globe Points
+ * Maximum Distance Allowed between Two Globe Points in order to Draw an Arc
  *
- * @note If curve distance is too large for a given sphere, the curves will clip into the sphere
+ * @note This will prevent Arcs from being drawn between points with distance > ARC_MAX_DISTANCE
  */
-export const CURVE_MAX_DISTANCE = 200;
+export const ARC_MAX_DISTANCE = 300;
+
+/**
+ * Arc Point Distance at which Arc Length should begin increasing linearly to account for Arcs with
+ * exceptionally large distance (ex: across globe, 180 degrees).
+ *
+ * @note This dynamically adds scaling extra height to Arc Mid-Points when the distance between the
+ * Two Arc Points is > ARC_DISTANCE_OFFSET, which prevents large Arcs from clipping into the Globe.
+ *
+ * @note The final Arc Length Offset is: ARC_LENGTH_OFFSET + ((distance - ARC_DISTANCE_OFFSET) * 2)
+ */
+export const ARC_DISTANCE_OFFSET = 225;
+
+/**
+ * Minimum Arc Length to be Added to Calculated Arc Length (based on distance)
+ *
+ * @note This adds extra height to all Arc Mid-Points by increasing the total length of a given Arc
+ * without changing the distance between the two points.
+ */
+export const ARC_LENGTH_OFFSET = 10;
 
 export const GLOBE_DOT_MIN_OPACITY = 0.125;
 export const GLOBE_DOT_RADIUS = 2.9;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -6,7 +6,7 @@ export const COLOR_1 = '#ef0018';
  *
  * @note If curve distance is too large for a given sphere, the curves will clip into the sphere
  */
-export const CURVE_MAX_DISTANCE = 225;
+export const CURVE_MAX_DISTANCE = 200;
 
 export const GLOBE_DOT_MIN_OPACITY = 0.125;
 export const GLOBE_DOT_RADIUS = 2.9;

--- a/src/objects/Earth.js
+++ b/src/objects/Earth.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-use-before-define */
 import * as THREE from 'three';
 import * as TWEEN from 'tween.js';
-import { TOTAL_ARCS } from '../constants';
+import { CURVE_MAX_DISTANCE, TOTAL_ARCS } from '../constants';
 import drawCurve from './drawCurve';
 import drawPoints from './globePoints';
 import {
@@ -46,8 +46,14 @@ export class Earth {
 
       for (let i = 0; i < TOTAL_ARCS; i += 1) {
         const randPoints = getRandomArrayElements(points[0], 2);
-        const newLine = drawCurve(randPoints[0].position, randPoints[1].position);
+        const a = randPoints[0].position;
+        const b = randPoints[1].position;
+        const distance = a.clone().sub(b).length();
+        if (distance > CURVE_MAX_DISTANCE) {
+          continue;
+        }
 
+        const newLine = drawCurve(a, b);
         drawArc(newLine, i);
       }
     }

--- a/src/objects/Earth.js
+++ b/src/objects/Earth.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-use-before-define */
 import * as THREE from 'three';
 import * as TWEEN from 'tween.js';
-import { CURVE_MAX_DISTANCE, TOTAL_ARCS } from '../constants';
+import { ARC_MAX_DISTANCE, TOTAL_ARCS } from '../constants';
 import drawCurve from './drawCurve';
 import drawPoints from './globePoints';
 import {
@@ -49,12 +49,9 @@ export class Earth {
         const a = randPoints[0].position;
         const b = randPoints[1].position;
         const distance = a.clone().sub(b).length();
-        if (distance > CURVE_MAX_DISTANCE) {
-          continue;
+        if (distance <= ARC_MAX_DISTANCE) {
+          drawArc(drawCurve(a, b), i);
         }
-
-        const newLine = drawCurve(a, b);
-        drawArc(newLine, i);
       }
     }
 

--- a/src/objects/drawCurve/index.js
+++ b/src/objects/drawCurve/index.js
@@ -1,23 +1,24 @@
 import * as THREE from 'three';
-import { COLOR_1 } from '../../constants';
+import { ARC_DISTANCE_OFFSET, ARC_LENGTH_OFFSET, COLOR_1 } from '../../constants';
 
 export default function drawCurve(a, b) {
   const distance = a.clone().sub(b).length();
+  let distanceOffset = distance - ARC_DISTANCE_OFFSET;
+  if (distanceOffset < 0) {
+    distanceOffset = 0;
+  }
 
   const mid = a.clone().lerp(b, 0.5);
-  const midLength = mid.length();
+  const midOffset = ARC_LENGTH_OFFSET + (distanceOffset * 2);
+  const midLength = mid.length() + midOffset;
   mid.normalize();
   mid.multiplyScalar(midLength + distance * 0.25);
 
   const normal = new THREE.Vector3().subVectors(a, b);
   normal.normalize();
 
-  const midStart = mid
-    .clone()
-    .add(normal.clone().multiplyScalar(distance * 0.25));
-  const midEnd = mid
-    .clone()
-    .add(normal.clone().multiplyScalar(distance * -0.25));
+  const midStart = mid.clone().add(normal.clone().multiplyScalar(distance * 0.25));
+  const midEnd = mid.clone().add(normal.clone().multiplyScalar(distance * -0.25));
 
   const splineCurveA = new THREE.CubicBezierCurve3(a, a, midStart, mid);
   const splineCurveB = new THREE.CubicBezierCurve3(mid, midEnd, b, b);
@@ -29,7 +30,7 @@ export default function drawCurve(a, b) {
 
   const lineGeometry = new THREE.BufferGeometry();
   const positions = new Float32Array(points.length * 3);
-  for (let i = 0; i < points.length; i++) {
+  for (let i = 0; i < points.length; i += 1) {
     positions[i * 3 + 0] = points[i].x;
     positions[i * 3 + 1] = points[i].y;
     positions[i * 3 + 2] = points[i].z;

--- a/src/objects/drawCurve/index.js
+++ b/src/objects/drawCurve/index.js
@@ -29,7 +29,7 @@ export default function drawCurve(a, b) {
 
   const lineGeometry = new THREE.BufferGeometry();
   const positions = new Float32Array(points.length * 3);
-  for (let i = 0; i < points.length; i += 1) {
+  for (let i = 0; i < points.length; i++) {
     positions[i * 3 + 0] = points[i].x;
     positions[i * 3 + 1] = points[i].y;
     positions[i * 3 + 2] = points[i].z;

--- a/src/objects/drawCurve/index.js
+++ b/src/objects/drawCurve/index.js
@@ -29,15 +29,17 @@ export default function drawCurve(a, b) {
 
   const lineGeometry = new THREE.BufferGeometry();
   const positions = new Float32Array(points.length * 3);
-  for (let ii = 0; ii < points.length; ii += 1) {
-    positions[ii * 3 + 0] = points[ii].x;
-    positions[ii * 3 + 1] = points[ii].y;
-    positions[ii * 3 + 2] = points[ii].z;
+  for (let i = 0; i < points.length; i += 1) {
+    positions[i * 3 + 0] = points[i].x;
+    positions[i * 3 + 1] = points[i].y;
+    positions[i * 3 + 2] = points[i].z;
   }
+
   lineGeometry.setAttribute(
     'position',
     new THREE.BufferAttribute(positions, 3),
   );
+
   lineGeometry.setDrawRange(0, 0);
 
   const lineMaterial = new THREE.LineBasicMaterial({


### PR DESCRIPTION
# Overview
I added configurable Globe Arc constants that change Arc Generation Behavior. In general, these prevent Arcs from clipping into the Earth Sphere with the current values.

The following Arc constants were added:
1. `ARC_DISTANCE_OFFSET` - Arc Point Distance at which Arc Length should begin increasing linearly
2. `ARC_LENGTH_OFFSET` - Minimum Arc Length to be added to Calculated Arc Length (based on distance)
3. `ARC_MAX_DISTANCE` - Maximum Distance Allowed between Two Arc Points in order to draw an Arc

`ARC_DISTANCE_OFFSET` adds extra length, linearly scaling with distance > ARC_DISTANCE_OFFSET, to Arcs where the distance between the Two Arc Points is greater than ARC_DISTANCE_OFFSET.

`ARC_LENGTH_OFFSET` adds extra length to all Arcs, increasing the height of the Arc Mid-Point, which increases the "height" (above globe) the Arc uses.

`ARC_MAX_DISTANCE` can prevent curves from clipping into the Earth Sphere, but alone and if set to a value lower than the distance between the largest Arcs will also prevent those Arcs with exceptionally large distance from ever being drawn if the distance is > this maximum value.

## Testing Steps
- [ ] Ensure Arcs NEVER clip into the Earth Sphere
  - [ ] Rotate Earth in as many ways as possible to attempt to draw ALL Arcs
  - [ ] All Arcs (red lines) should be above the Earth Geometry at all times
  - [ ] Ensure "Small" Arc Angle/Distance is desired (not too high, never clips, etc.)
  - [ ] Ensure "Medium" Arc Angle/Distance is desired (not too high, never clips, etc.)
  - [ ] Ensure "Large" Arc Angle/Distance is desired (not too high, never clips, etc.)
