### PR TITLE
Fix Click Issue

### DIFF
--- a/src/scene/index.js
+++ b/src/scene/index.js
@@ -65,8 +65,9 @@ export function render() {
 }
 
 function onClick(event) {
-  mouse2.x = (event.clientX / window.innerWidth) * 2 - 1;
-  mouse2.y = -(event.clientY / window.innerHeight) * 2 + 1;
+  const rect = renderer.domElement.getBoundingClientRect();
+  mouse2.x = ((event.clientX - rect.left) / (rect.right - rect.left)) * 2 - 1;
+  mouse2.y = -((event.clientY - rect.top) / (rect.bottom - rect.top)) * 2 + 1;
 
   raycaster.setFromCamera(mouse2, camera);
   // Find all intersectioned object, and filter by named objects only.


### PR DESCRIPTION
## Description

This PR fixes the issue of the clicking on the location markers not working. This makes the click position relative to the canvas position so that the clicks aren't off (Robert can probably explain that better).

You won't really be able to tell any difference when you running this project locally since the canvas isn't inside a container or having any CSS applied to it that would change it's position (like `margin-left: 200px`), but over on CableLabs we are doing things like that, so this fix is key over there.