### PR TITLE
Added Arc Gradient Color Configuration

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -12,7 +12,7 @@ export const ARC_COLOR_BEGIN = [255, 0, 0]; // Red
 /**
  * Arc Color that the end of the Arc should be drawn with.
  *
- * @note If set to a different color than ARC_COLOR_END, it will apply a Smooth Gradient to the
+ * @note If set to a different color than ARC_COLOR_BEGIN, it will apply a Smooth Gradient to the
  * Arc Color, easing between the two colors (BEGIN and END).
  *
  */

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 
 /**
- * Arc Color that the start of the Arc should be drawn with.
+ * Arc Color (RGB) that the start of the Arc should be drawn with.
  *
  * @note If set to a different color than ARC_COLOR_END, it will apply a Smooth Gradient to the
  * Arc Color, easing between the two colors (BEGIN and END).
@@ -10,7 +10,7 @@
 export const ARC_COLOR_BEGIN = [255, 0, 0]; // Red
 
 /**
- * Arc Color that the end of the Arc should be drawn with.
+ * Arc Color (RGB) that the end of the Arc should be drawn with.
  *
  * @note If set to a different color than ARC_COLOR_BEGIN, it will apply a Smooth Gradient to the
  * Arc Color, easing between the two colors (BEGIN and END).

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,6 +1,24 @@
 /* eslint-disable import/prefer-default-export */
 
 /**
+ * Arc Color that the start of the Arc should be drawn with.
+ *
+ * @note If set to a different color than ARC_COLOR_END, it will apply a Smooth Gradient to the
+ * Arc Color, easing between the two colors (BEGIN and END).
+ *
+ */
+export const ARC_COLOR_BEGIN = [255, 0, 0]; // Red
+
+/**
+ * Arc Color that the end of the Arc should be drawn with.
+ *
+ * @note If set to a different color than ARC_COLOR_END, it will apply a Smooth Gradient to the
+ * Arc Color, easing between the two colors (BEGIN and END).
+ *
+ */
+export const ARC_COLOR_END = [140, 0, 255]; // Purple
+
+/**
  * Arc Point Distance at which Arc Length should begin increasing linearly to account for Arcs with
  * exceptionally large distance (ex: across globe, 180 degrees).
  *

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -42,7 +42,7 @@ export const ARC_LENGTH_OFFSET = 10;
  *
  * @note This will prevent Arcs from being drawn between points with distance > ARC_MAX_DISTANCE
  */
-export const ARC_MAX_DISTANCE = 300;
+export const ARC_MAX_DISTANCE = 250;
 
 export const COLOR_1 = '#ef0018';
 export const BRAND_COLORS = [COLOR_1, '#DB1F3B', '#CE1D41', '#C11B47', '#B41A4D', '#A71853', '#9A1659', '#8C1460', '#791269'];

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -5,7 +5,6 @@
  *
  * @note If set to a different color than ARC_COLOR_END, it will apply a Smooth Gradient to the
  * Arc Color, easing between the two colors (BEGIN and END).
- *
  */
 export const ARC_COLOR_BEGIN = [255, 0, 0]; // Red
 
@@ -14,7 +13,6 @@ export const ARC_COLOR_BEGIN = [255, 0, 0]; // Red
  *
  * @note If set to a different color than ARC_COLOR_BEGIN, it will apply a Smooth Gradient to the
  * Arc Color, easing between the two colors (BEGIN and END).
- *
  */
 export const ARC_COLOR_END = [140, 0, 255]; // Purple
 

--- a/src/objects/drawCurve/index.js
+++ b/src/objects/drawCurve/index.js
@@ -42,7 +42,6 @@ export default function drawCurve(a, b) {
   const colorDiffB = -(colorBegin[2] - colorEnd[2]);
   const colors = [];
   const pointCount = points.length;
-  const positions = new Float32Array(points.length * 3);
   const vertices = [];
   for (let i = 0; i < pointCount; i += 1) {
     const point = points[i];
@@ -53,9 +52,6 @@ export default function drawCurve(a, b) {
     const hsl = rgbToHsl(colorBegin[0] + deltaR, colorBegin[1] + deltaG, colorBegin[2] + deltaB);
     color.setHSL(hsl[0], 1.0, 0.5);
     colors.push(color.r, color.g, color.b);
-    positions[i * 3] = point.x;
-    positions[i * 3 + 1] = points[i].y;
-    positions[i * 3 + 2] = points[i].z;
     vertices.push(point.x, point.y, point.z);
   }
 

--- a/src/objects/drawCurve/index.js
+++ b/src/objects/drawCurve/index.js
@@ -44,7 +44,7 @@ export default function drawCurve(a, b) {
   const pointCount = points.length;
   const positions = new Float32Array(points.length * 3);
   const vertices = [];
-  for (let i = 0; i < points.length; i += 1) {
+  for (let i = 0; i < pointCount; i += 1) {
     const point = points[i];
     const ratio = i / Number(pointCount);
     const deltaR = colorDiffR * ratio;

--- a/src/objects/drawCurve/index.js
+++ b/src/objects/drawCurve/index.js
@@ -47,9 +47,9 @@ export default function drawCurve(a, b) {
   for (let i = 0; i < points.length; i += 1) {
     const point = points[i];
     const ratio = i / Number(pointCount);
-    const deltaB = colorDiffB * ratio;
-    const deltaG = colorDiffG * ratio;
     const deltaR = colorDiffR * ratio;
+    const deltaG = colorDiffG * ratio;
+    const deltaB = colorDiffB * ratio;
     const hsl = rgbToHsl(colorBegin[0] + deltaR, colorBegin[1] + deltaG, colorBegin[2] + deltaB);
     color.setHSL(hsl[0], 1.0, 0.5);
     colors.push(color.r, color.g, color.b);

--- a/src/objects/drawCurve/index.js
+++ b/src/objects/drawCurve/index.js
@@ -64,8 +64,7 @@ export default function drawCurve(a, b) {
   geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
   geometry.setDrawRange(0, 0);
 
-  const material = new THREE.LineBasicMaterial({ vertexColors: true });
-  material.transparent = true;
+  const material = new THREE.LineBasicMaterial({ transparent: true, vertexColors: true });
 
   const line = new THREE.Line(geometry, material);
   line.currentPoint = 0;

--- a/src/objects/drawCurve/index.js
+++ b/src/objects/drawCurve/index.js
@@ -64,7 +64,12 @@ export default function drawCurve(a, b) {
   geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
   geometry.setDrawRange(0, 0);
 
-  const material = new THREE.LineBasicMaterial({ transparent: true, vertexColors: true });
+  const material = new THREE.LineBasicMaterial({
+    linewidth: 2,
+    opacity: 0.75,
+    transparent: true,
+    vertexColors: true,
+  });
 
   const line = new THREE.Line(geometry, material);
   line.currentPoint = 0;

--- a/src/objects/drawCurve/index.js
+++ b/src/objects/drawCurve/index.js
@@ -45,7 +45,7 @@ export default function drawCurve(a, b) {
   const vertices = [];
   for (let i = 0; i < pointCount; i += 1) {
     const point = points[i];
-    const ratio = i / Number(pointCount);
+    const ratio = i / pointCount;
     const deltaR = colorDiffR * ratio;
     const deltaG = colorDiffG * ratio;
     const deltaB = colorDiffB * ratio;

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -97,10 +97,10 @@ function genRandDecimal(min, max, decimalPlaces = 1) {
  * Assumes r, g, and b are contained in the set [0, 255] and
  * returns h, s, and l in the set [0, 1].
  *
- * @param   Number  r       The red color value
- * @param   Number  g       The green color value
- * @param   Number  b       The blue color value
- * @return  Array           The HSL representation
+ * @param Number red - The red color value
+ * @param Number green - The green color value
+ * @param Number blue - The blue color value
+ * @return Array - The HSL representation
  */
 function rgbToHsl(red, green, blue) {
   const r = red / 255;

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -91,6 +91,48 @@ function genRandDecimal(min, max, decimalPlaces = 1) {
   return Math.floor(rand * power) / power;
 }
 
+/**
+ * Converts an RGB color value to HSL. Conversion formula
+ * adapted from http://en.wikipedia.org/wiki/HSL_color_space.
+ * Assumes r, g, and b are contained in the set [0, 255] and
+ * returns h, s, and l in the set [0, 1].
+ *
+ * @param   Number  r       The red color value
+ * @param   Number  g       The green color value
+ * @param   Number  b       The blue color value
+ * @return  Array           The HSL representation
+ */
+function rgbToHsl(red, green, blue) {
+  const r = red / 255;
+  const g = green / 255;
+  const b = blue / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h;
+  let s;
+  const l = (max + min) / 2;
+
+  if (max === min) {
+    h = 0;
+    s = 0; // achromatic
+  } else {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+
+    // eslint-disable-next-line default-case
+    switch (max) {
+      case r: h = (g - b) / d + (g < b ? 6 : 0); break;
+      case g: h = (b - r) / d + 2; break;
+      case b: h = (r - g) / d + 4; break;
+    }
+
+    h /= 6;
+  }
+
+  return [h, s, l];
+}
+
 export {
   latLongToVector3,
   cartesian2polar,
@@ -100,4 +142,5 @@ export {
   getPixel,
   getRandomArrayElements,
   genRandDecimal,
+  rgbToHsl,
 };


### PR DESCRIPTION
## Overview
I added two new constants that affect Arc Color:
1. `ARC_COLOR_BEGIN`
2. `ARC_COLOR_END`

These constants are expected to be arrays with 3 values in them, `R`, `G`, and `B` 🐒 

`ARC_COLOR_BEGIN` is currently set to `red` (`[255, 0, 0]`).

`ARC_COLOR_END` is currently set to `purple` (`[140, 0, 255]`).

I also refactored Arc Generation Behavior by applying a `color` property to the Arc Geometry Vertices.

This provides us configurable Arc Colors. The Gradient Behavior is "optional", in that if you set `ARC_COLOR_BEGIN` and `ARC_COLOR_END` to the same value, the Arc will be a single solid color 🐒 

This also required adding a new Utility Method, `rgbToHsl` which coverts a given RGB (Red Green Blue) value into an HSL (Hue Saturation Lightness). Not really sure why, but attempting to apply RGB values as Vertex Colors result in the line being split in half, each half being one solid color (start and end). We only use the `Hue` in the returned HSL, keeping Saturation and Lightness constant at 1.0 and 0.5 respectively 🐒 Which was confusing to me, not sure why that is tbh, but this works 🤷 