### PR TITLE
Added Location Marker Auto-Selection Initialization Delay

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -55,7 +55,7 @@ export const GLOBE_DOT_RADIUS = 2.9;
  * @note This also determines the amount of time between each Auto-Selection of Location Markers
  * once "autoplay" has begun.
  */
-export const MARKER_AUTO_SELECT_DELAY = 15000;
+export const MARKER_AUTO_SELECT_DELAY = 5000;
 
 /**
  * Amount of Time, in milliseconds, before Location Marker Auto-Selection should begin.

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -55,7 +55,14 @@ export const GLOBE_DOT_RADIUS = 2.9;
  * @note This also determines the amount of time between each Auto-Selection of Location Markers
  * once "autoplay" has begun.
  */
-export const MARKER_AUTO_SELECT_DELAY = 5000;
+export const MARKER_AUTO_SELECT_DELAY = 15000;
+
+/**
+ * Amount of Time, in milliseconds, before Location Marker Auto-Selection should begin.
+ *
+ * @note If set to 0, it will begin after MARKER_AUTO_SELECT_DELAY
+ */
+export const MARKER_AUTO_SELECT_INIT_AFTER = 1000;
 
 /**
  * The Maximum Distance from the Camera at which Auto-Selected Location Markers can be chosen.


### PR DESCRIPTION
## Overview
I added a new constant:
1. `MARKER_AUTO_SELECT_INIT_AFTER` - Amount of Time, in milliseconds, before Location Marker Auto-Selection should begin.

This is an optional configuration that allows us to modify how quickly the first Location Marker Auto-Selection will occur on page load. This only affects the time after page load for auto-play to begin.

If set to 0, it will essentially use `MARKER_AUTO_SELECT_DELAY` as it was 🐒 

This was a request from Kyle:
> is it possible to show the first active dot like 1 second after the globe is loaded on first page load?