### PR TITLE
Added Globe Position/Rotation Freeze when Hovering

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -49,6 +49,13 @@ export const GLOBE_DOT_MIN_OPACITY = 0.125;
 export const GLOBE_DOT_RADIUS = 2.9;
 
 /**
+ * Determines if the Globe Rotation/Position should "freeze" when Hovering the Mouse over it.
+ *
+ * @note This will not "freeze" Arc / Location Marker Auto-Selection
+ */
+export const GLOBE_HOVER_FREEZE_ENABLED = true;
+
+/**
  * Amount of Time, in milliseconds, before Auto-Selection of Location Markers should begin after no
  * User-Selection has occurred.
  *

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -51,7 +51,8 @@ export const GLOBE_DOT_RADIUS = 2.9;
 /**
  * Determines if the Globe Rotation/Position should "freeze" when Hovering the Mouse over it.
  *
- * @note This will not "freeze" Arc / Location Marker Auto-Selection
+ * @note This will "freeze" Location Marker Auto-Selection
+ * @note This will not "freeze" Arcs
  */
 export const GLOBE_HOVER_FREEZE_ENABLED = true;
 

--- a/src/objects/Earth/index.js
+++ b/src/objects/Earth/index.js
@@ -23,6 +23,7 @@ import { drawEarth } from '../sphere';
 import {
   createScene,
   getCamera,
+  isHovering,
   render,
 } from '../../scene';
 import data from '../../data/member_companies.json';
@@ -73,6 +74,10 @@ export class Earth {
       let lastRandom;
       const raycaster = new THREE.Raycaster();
       setInterval(() => {
+        if (isHovering()) {
+          return;
+        }
+
         // eslint-disable-next-line prefer-destructuring
         current = window.document.getElementsByClassName('location visible')[0];
         if (current && current.childNodes) {

--- a/src/scene/index.js
+++ b/src/scene/index.js
@@ -35,7 +35,7 @@ const targetOnDown = {
 const w = window.innerWidth;
 const h = window.innerHeight;
 const camera = new THREE.PerspectiveCamera(camDistance / 5, w / h, 1, camDistance * 2);
-let isHovering = false;
+let hover = false;
 let renderer;
 let scene;
 
@@ -53,8 +53,12 @@ export function getCamera() {
   return camera;
 }
 
+export function isHovering() {
+  return hover;
+}
+
 export function render() {
-  if (!isHovering || !GLOBE_HOVER_FREEZE_ENABLED) {
+  if (!hover || !GLOBE_HOVER_FREEZE_ENABLED) {
     target.x += 0.00075;
     rotation.x += (target.x - rotation.x) * 0.1;
     rotation.y += (target.y - rotation.y) * 0.1;
@@ -151,8 +155,8 @@ function onMouseHoverMove() {
 
   raycaster.setFromCamera(mouse2, camera);
   const intersects = raycaster.intersectObjects(scene.children);
-  isHovering = !!intersects[0];
-  canvas.style.cursor = isHovering ? 'pointer' : 'grab';
+  hover = !!intersects[0];
+  canvas.style.cursor = hover ? 'pointer' : 'grab';
 }
 
 function onMouseOut() {


### PR DESCRIPTION
## Overview
I added a new configuration:
1. `GLOBE_HOVER_FREEZE_ENABLED` - Determines if the Globe Rotation/Position should "freeze" when Hovering the Mouse over it.

When set to `true`, this will freeze the rotation/position of the Globe when hovering over it with the mouse cursor. More specifically, it will freeze when hovering over anything in the 3D World, not just the Globe, such as the Arcs 🐒 It will not freeze when hovering over Location Info Boxes because those are not in the 3D World 🐒 

However, Location Marker Selections will remain "frozen" as selected when hovering 🙂

I also fixed a bug with Mouse Pointer Type assignment. I believe the "grab" pointer was always being used due to a logic error in the intersections.filter 🐒 