### PR TITLE
Fixed Globe Drag Behavior Bug caused by Globe Hover Behavior

### DIFF
--- a/src/scene/index.js
+++ b/src/scene/index.js
@@ -37,6 +37,7 @@ const h = window.innerHeight;
 const camera = new THREE.PerspectiveCamera(camDistance / 5, w / h, 1, camDistance * 2);
 let drag = false;
 let hover = false;
+let hoverMarker = false;
 let renderer;
 let scene;
 
@@ -166,9 +167,11 @@ function onMouseOver() {
 
 function onMouseHoverMove(event) {
   raycaster.setFromCamera(getMouse(event), camera);
-  const intersects = raycaster.intersectObjects(scene.children);
+  const intersects = raycaster.intersectObjects(scene.children, true);
+  const filter = intersects.filter((intersect) => intersect.object.parent?.name);
   hover = !!intersects[0];
-  canvas.style.cursor = hover ? 'pointer' : 'grab';
+  hoverMarker = hover && !!filter[0];
+  canvas.style.cursor = hoverMarker ? 'pointer' : 'grab';
 }
 
 function onMouseOut() {

--- a/src/scene/index.js
+++ b/src/scene/index.js
@@ -35,6 +35,7 @@ const targetOnDown = {
 const w = window.innerWidth;
 const h = window.innerHeight;
 const camera = new THREE.PerspectiveCamera(camDistance / 5, w / h, 1, camDistance * 2);
+let drag = false;
 let hover = false;
 let renderer;
 let scene;
@@ -53,22 +54,26 @@ export function getCamera() {
   return camera;
 }
 
+export function isDragging() {
+  return drag;
+}
+
 export function isHovering() {
   return hover;
 }
 
 export function render() {
-  if (!hover || !GLOBE_HOVER_FREEZE_ENABLED) {
+  const freeze = !hover || drag || !GLOBE_HOVER_FREEZE_ENABLED;
+  if (freeze) {
     target.x += 0.00075;
     rotation.x += (target.x - rotation.x) * 0.1;
     rotation.y += (target.y - rotation.y) * 0.1;
-    camera.lookAt(new THREE.Vector3(0, 0, 0));
   }
 
   camera.position.x = camDistance * Math.sin(rotation.x) * Math.cos(rotation.y);
   camera.position.y = camDistance * Math.sin(rotation.y);
   camera.position.z = camDistance * Math.cos(rotation.x) * Math.cos(rotation.y);
-
+  camera.lookAt(new THREE.Vector3(0, 0, 0));
   renderer.render(scene, camera);
 }
 
@@ -126,6 +131,10 @@ function onMouseDown(event) {
 }
 
 function onMouseDownMove(event) {
+  if (hover) {
+    drag = true;
+  }
+
   mouse.x = event.touches ? -event.touches[0].clientX : -event.clientX;
   mouse.y = event.touches ? event.touches[0].clientY : event.clientY;
 
@@ -141,6 +150,11 @@ function onMouseUp() {
   canvas.removeEventListener('mouseup', onMouseUp, false);
   canvas.addEventListener('mousemove', onMouseHoverMove, false);
   canvas.style.cursor = 'grab';
+
+  // Allow Drag Rotation "inertia" to continue for 500ms after dragging ends
+  setTimeout(() => {
+    drag = false;
+  }, 500);
 }
 
 function onMouseOver() {

--- a/src/scene/index.js
+++ b/src/scene/index.js
@@ -54,6 +54,13 @@ export function getCamera() {
   return camera;
 }
 
+export function getMouse(event) {
+  const rect = renderer.domElement.getBoundingClientRect();
+  mouse2.x = ((event.clientX - rect.left) / (rect.right - rect.left)) * 2 - 1;
+  mouse2.y = -((event.clientY - rect.top) / (rect.bottom - rect.top)) * 2 + 1;
+  return mouse2;
+}
+
 export function isDragging() {
   return drag;
 }
@@ -80,12 +87,7 @@ export function render() {
 let lastClicked = null;
 
 function onMouseDown(event) {
-  // Determine if the user is clicking a location marker or attempting to grab the globe
-  const rect = renderer.domElement.getBoundingClientRect();
-  mouse2.x = ((event.clientX - rect.left) / (rect.right - rect.left)) * 2 - 1;
-  mouse2.y = -((event.clientY - rect.top) / (rect.bottom - rect.top)) * 2 + 1;
-
-  raycaster.setFromCamera(mouse2, camera);
+  raycaster.setFromCamera(getMouse(event), camera);
   // Find all intersected objects, and filter by those in a named group only.
   // Each marker consists of a
   // - point (colored dot)
@@ -162,12 +164,8 @@ function onMouseOver() {
   canvas.addEventListener('mousemove', onMouseHoverMove, false);
 }
 
-function onMouseHoverMove() {
-  const rect = renderer.domElement.getBoundingClientRect();
-  mouse2.x = ((event.clientX - rect.left) / (rect.right - rect.left)) * 2 - 1;
-  mouse2.y = -((event.clientY - rect.top) / (rect.bottom - rect.top)) * 2 + 1;
-
-  raycaster.setFromCamera(mouse2, camera);
+function onMouseHoverMove(event) {
+  raycaster.setFromCamera(getMouse(event), camera);
   const intersects = raycaster.intersectObjects(scene.children);
   hover = !!intersects[0];
   canvas.style.cursor = hover ? 'pointer' : 'grab';


### PR DESCRIPTION
## Overview
I fixed a bug caused by #10 where due to the logic that was freezing the Globe Rotation/Position, the ability to "drag" the globe in order to rotate it was not working as expected.

This should restore the Globe Drag Rotation Behavior functionality 🐒 

Additionally, to make the two behaviors play nicely, I made it so that for a `500ms` duration after Globe Dragging has ended, the Globe is allowed to continue to rotate matching the "inertia" of the "drag" motion. For example, a Hard Drag-n-Drop of the Globe would cause it to keep rotating in the direction one dragged it in, essentially maintaining "rotational velocity".

`500ms` after dragging has ended, the `Hover Freeze Behavior` will be allowed to work again 🐒 If not hovering over the Globe when this duration ends, then the Globe will simply maintain the "rotational velocity" of the drag as it had worked prior to the Hover Freeze functionality being added 🐒 

I also made the Mouse Pointer be a `Cursor` only when hovering over a Location Marker. It will be `Grab` at all other times 🐒 