### PR TITLE
Added Clicked-Nothing Event to Hide Marker/Location Selections

### DIFF
--- a/src/scene/highlightPoint.js
+++ b/src/scene/highlightPoint.js
@@ -26,13 +26,20 @@ export function highlightPoint(locationMarkerGroup) {
 
 export function clearHighlightedPoint() {
   if (state.highlightedPoint) {
-    state.currentTweenAnimation.stop();
-    state.currentRingAnimation.stop();
+    if (state.currentTweenAnimation) {
+      state.currentTweenAnimation.stop();
+    }
+
+    if (state.currentRingAnimation) {
+      state.currentRingAnimation.stop();
+    }
 
     deflatePoint(state.highlightedPoint).start();
     deflateRing(state.highlightedPointRing)
       .onComplete(() => {
-        state.previousSpinAnimation.stop();
+        if (state.previousSpinAnimation) {
+          state.previousSpinAnimation.stop();
+        }
       })
       .start();
 

--- a/src/scene/index.js
+++ b/src/scene/index.js
@@ -81,20 +81,29 @@ function onMouseDown(event) {
   mouse2.y = -((event.clientY - rect.top) / (rect.bottom - rect.top)) * 2 + 1;
 
   raycaster.setFromCamera(mouse2, camera);
-  // Find all intersected objects, and filter by those in a named group only.
-  // Each marker consists of a
-  // - point (colored dot)
-  // - ring (a ring around the marker)
-  // - hitbox (a sphere object that is used for detecting clicks)
-  // The location marker groups are the only objects we care about.
-  const intersects = raycaster
-    .intersectObjects(scene.children, true)
-    .filter((intersect) => intersect.object.parent?.name);
 
-  if (intersects.length > 0) {
-    const locationMarkerGroup = intersects[0].object.parent;
-    // Ignore second clicks on already highlighted markers.
-    // This helps helps avoid stacking animations and other edge cases.
+  const intersects = raycaster.intersectObjects(scene.children, true);
+  if (!intersects || !intersects[0]) {
+    console.log('Clicked Nothing!');
+    clearHighlightedPoint();
+    const selection = window.document.getElementsByClassName('location visible')[0];
+    if (selection && selection.classList) {
+      selection.classList.remove('visible');
+    }
+  }
+
+  /**
+   * Find all intersected objects, and filter by those in a named group only.
+   *
+   * Each marker consists of a:
+   * - point (colored dot)
+   * - ring (a ring around the marker)
+   * - hitbox (a sphere object that is used for detecting clicks)
+   */
+  const filter = intersects.filter((intersect) => intersect.object.parent?.name);
+  if (filter.length > 0) {
+    const locationMarkerGroup = filter[0].object.parent;
+    // Ignore second clicks on already highlighted markers (avoids edge cases)
     if (lastClicked?.uuid === locationMarkerGroup.uuid) {
       return;
     }
@@ -102,10 +111,10 @@ function onMouseDown(event) {
     clearHighlightedPoint();
     highlightPoint(locationMarkerGroup);
 
-    if (intersects[0]) {
+    if (filter[0]) {
       canvas.style.cursor = 'pointer';
       onLocationClick(event, {
-        locationId: intersects[0].object.parent.name,
+        locationId: filter[0].object.parent.name,
       });
       lastClicked = locationMarkerGroup;
     }

--- a/src/scene/index.js
+++ b/src/scene/index.js
@@ -83,6 +83,8 @@ function onMouseDown(event) {
   raycaster.setFromCamera(mouse2, camera);
 
   const intersects = raycaster.intersectObjects(scene.children, true);
+
+  // Handle Event: "Clicked Nothing" (deselect/hide selections)
   if (!intersects || !intersects[0]) {
     clearHighlightedPoint();
     const selection = window.document.getElementsByClassName('location visible')[0];

--- a/src/scene/index.js
+++ b/src/scene/index.js
@@ -84,7 +84,6 @@ function onMouseDown(event) {
 
   const intersects = raycaster.intersectObjects(scene.children, true);
   if (!intersects || !intersects[0]) {
-    console.log('Clicked Nothing!');
     clearHighlightedPoint();
     const selection = window.document.getElementsByClassName('location visible')[0];
     if (selection && selection.classList) {


### PR DESCRIPTION
## Overview
I added a "Clicked Nothing" Event that will remove the current Location Marker Selection, which includes hiding the Info Box, whenever the User clicks an area where no 3D Objects exist (the black space around Globe).

I also improved `highlightPoint::clearHighlightedPoint` resiliency by checking nested objects for existence to prevent using undefined values as objects 🐒 I believe the issue I found would occur if `clearHighlightedPoint()` was run before any invocation to `highlightPoint::highlightPoint` 🐒 

I will work with @trevormiles to determine if this behavior will work when implemented on the CableLabs page, or if we will need some custom Javascript to remove the selection marker / info box.